### PR TITLE
Fixed game breaking bug 

### DIFF
--- a/Assets/Scripts/UI/PopupMenu/PopupTrigger.cs
+++ b/Assets/Scripts/UI/PopupMenu/PopupTrigger.cs
@@ -20,10 +20,11 @@ public class PopupTrigger : MonoBehaviour
 
             ActivateCloudOutline();
 
-            GameManager.IsPaused = !GameManager.IsPaused;
-            GameManager.CursorIsLocked = !GameManager.CursorIsLocked;
-            Time.timeScale = GameManager.IsPaused ? 0 : 1;
+            GameManager.IsPaused = true;
+            GameManager.CursorIsLocked = false;
+            Time.timeScale = 0;
 
+            other.GetComponent<LevitateBehaviour>().RemoveRigidbodyAndStartFreeze();
             Popup.gameObject.SetActive(true);
             _hasBeenTriggered = true;
         }


### PR DESCRIPTION
Popup trigger and levitation froze the game together when both were active. PopupTrigger will no longer turn GameManger values, but will instead turn them into what they should be. PopupTrigger will also active the ReleaseRigidbodyAndStartFreeze function from LevitateBehaviour so that the object you were levitating will freeze in its place.
