### PR TITLE
Fixed levitation bug in cutscene

### DIFF
--- a/Assets/Scripts/Player/PlayerBehaviour.cs
+++ b/Assets/Scripts/Player/PlayerBehaviour.cs
@@ -210,6 +210,7 @@ public class PlayerBehaviour : BaseMovement
 
     private void HandleLevitationInput()
     {
+        if (GameManager.IsCutscenePlaying) return;
         LevitateBehaviour.CurrentLevitateableObjects = LevitateBehaviour.FindLevitateableObjectsInFrontOfPlayer();
         LevitateBehaviour.SetCurrentHighlightedObject(HighlightBehaviour.HighlightGameobject(_highlightRadiuses));
         if (Input.GetMouseButtonDown(0)) LevitateBehaviour.LevitationStateHandler();


### PR DESCRIPTION
A little fix about levitation: you can no longer levitate objects while the cutscene is playing.